### PR TITLE
Fix the same issue faced in ToFirstLine for DrawBars

### DIFF
--- a/ftplugin/tab/tabs.vim
+++ b/ftplugin/tab/tabs.vim
@@ -81,8 +81,9 @@ for c in keys(g:Chords)
     silent execute "nnoremap <localleader>". c." :call <SID>Chord(\"". c. "\")<CR>"
 endfor
 
-" replace the column with | and jump back vith ^o
+" Mapping to draw bars with -| in normal mode and | in insert/replace mode
 nnoremap <silent> <expr> <localleader>\| <SID>OnStringLine() ? ':call tabs#DrawBars()<CR>':''
+inoremap <silent> <expr> \| <SID>OnStringLine() ? '<esc>l:call tabs#DrawBars()<CR>lgR':'\|'
 
 " selections
 nnoremap <expr> <S-v> <SID>OnStringLine() ? ':call <SID>ToFirstLine()<CR><C-v>5j':'<S-v>'

--- a/ftplugin/tab/tabs.vim
+++ b/ftplugin/tab/tabs.vim
@@ -23,6 +23,15 @@ function! tabs#DrawStrings(length)
     endfor
 endfunction
 
+function! tabs#DrawBars()
+    let l:jump_back = s:OnFirstLine()
+    call s:ToFirstLine()
+    silent execute "normal! \<C-v>5jr|"
+    if !l:jump_back
+        silent execute "normal! \<C-o>"
+    endif
+endfunction
+
 function! s:OnStringLine()
     return getline(line('.')) =~ "^[a-gA-G]\|.*-*.*" 
 endfunction
@@ -73,7 +82,7 @@ for c in keys(g:Chords)
 endfor
 
 " replace the column with | and jump back vith ^o
-nnoremap <expr> <localleader>\| <SID>OnStringLine() ? ':call <SID>ToFirstLine()<CR><C-v>5jr\|<C-[><C-o>':''
+nnoremap <silent> <expr> <localleader>\| <SID>OnStringLine() ? ':call tabs#DrawBars()<CR>':''
 
 " selections
 nnoremap <expr> <S-v> <SID>OnStringLine() ? ':call <SID>ToFirstLine()<CR><C-v>5j':'<S-v>'

--- a/ftplugin/tab/tabs.vim
+++ b/ftplugin/tab/tabs.vim
@@ -89,8 +89,8 @@ nnoremap <expr> <S-v> <SID>OnStringLine() ? ':call <SID>ToFirstLine()<CR><C-v>5j
 nmap <expr> yy <SID>OnStringLine() ? 'mm<S-v>y`m':'yy'
 
 " movement
-inoremap <expr> <Tab> <SID>OnStringLine() ? '<esc>jgR':'<Tab>'
-inoremap <expr> <S-Tab> <SID>OnStringLine() ? '<esc>kgR':'<Tab>'
+inoremap <expr> <Tab> <SID>OnStringLine() ? '<esc>jlgR':'<Tab>'
+inoremap <expr> <S-Tab> <SID>OnStringLine() ? '<esc>klgR':'<Tab>'
 
 " map insert mode to Replace mode if cursor on a string line
 nnoremap <expr> i <SID>OnStringChar() ? 'gR':'i'

--- a/ftplugin/tab/tabs.vim
+++ b/ftplugin/tab/tabs.vim
@@ -10,16 +10,16 @@ let g:loaded_VimTabs = 1
 let s:tuning=['e', 'B', 'G', 'D', 'A', 'E']
 
 function! s:InitTab(length)
-    execute "normal! i[]\<CR>\<CR>" 
+    silent execute "normal! i[]\<CR>\<CR>" 
     call tabs#DrawStrings(a:length)
     " reset position 
-    execute "normal! ggl"
+    silent execute "normal! ggl"
     startinsert
 endfunction
 
 function! tabs#DrawStrings(length)
     for @s in s:tuning
-        execute "normal! i\<C-R>s|\<C-o>". a:length. "a-\<esc>a|\<esc>o"
+        silent execute "normal! i\<C-R>s|\<C-o>". a:length. "a-\<esc>a|\<esc>o"
     endfor
 endfunction
 
@@ -49,17 +49,17 @@ function! s:ToFirstLine()
     if s:OnFirstLine()
         return
     endif
-    execute "normal! ?". s:tuning[0]. "?s+". (col(".")-1). "\<CR>"
+    silent execute "normal! ?". s:tuning[0]. "?s+". (col(".")-1). "\<CR>"
 endfunction
 
 function! s:Chord(Letter)
     normal mm
     call s:ToFirstLine()
     set ve=all
-    execute "normal! kR". a:Letter. "\<esc>j" 
+    silent execute "normal! kR". a:Letter. "\<esc>j" 
     set ve=
     for @r in g:Chords[a:Letter]
-        execute "normal! s\<C-R>r\<esc>j"
+        silent execute "normal! s\<C-R>r\<esc>j"
     endfor
     normal `m
 endfunction
@@ -69,7 +69,7 @@ endfunction
 " chord completion
 let maplocalleader = "-"
 for c in keys(g:Chords)
-    execute "nnoremap <localleader>". c." :call <SID>Chord(\"". c. "\")<CR>"
+    silent execute "nnoremap <localleader>". c." :call <SID>Chord(\"". c. "\")<CR>"
 endfor
 
 " replace the column with | and jump back vith ^o

--- a/ftplugin/tab/tabs.vim
+++ b/ftplugin/tab/tabs.vim
@@ -1,5 +1,5 @@
 " VimTabs.vim - A vim plugin for writing guitar tablature
-" Author: Andrew Kingery 
+" Author: Andrew Kingery
 " Version: 0.2
 
 if exists("g:loaded_VimTabs")
@@ -10,9 +10,9 @@ let g:loaded_VimTabs = 1
 let s:tuning=['e', 'B', 'G', 'D', 'A', 'E']
 
 function! s:InitTab(length)
-    silent execute "normal! i[]\<CR>\<CR>" 
+    silent execute "normal! i[]\<CR>\<CR>"
     call tabs#DrawStrings(a:length)
-    " reset position 
+    " reset position
     silent execute "normal! ggl"
     startinsert
 endfunction
@@ -33,11 +33,11 @@ function! tabs#DrawBars()
 endfunction
 
 function! s:OnStringLine()
-    return getline(line('.')) =~ "^[a-gA-G]\|.*-*.*" 
+    return getline(line('.')) =~ "^[a-gA-G]\|.*-*.*"
 endfunction
 
 function! s:OnStringChar()
-    return s:OnStringLine() && getline('.')[col('.')-1] == "-" 
+    return s:OnStringLine() && getline('.')[col('.')-1] == "-"
 endfunction
 
 function! s:OnFirstLine()
@@ -65,7 +65,7 @@ function! s:Chord(Letter)
     normal mm
     call s:ToFirstLine()
     set ve=all
-    silent execute "normal! kR". a:Letter. "\<esc>j" 
+    silent execute "normal! kR". a:Letter. "\<esc>j"
     set ve=
     for @r in g:Chords[a:Letter]
         silent execute "normal! s\<C-R>r\<esc>j"


### PR DESCRIPTION
With the previous implementation, there was an extra unnecessary <C-o>. Now, the `tabs#DrawBars` is a public function with checks if it's necessary to jump back.